### PR TITLE
Support `.tsx`

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -57,7 +57,7 @@ exports.extensions = {
     { icon: "python", extensions: ["py"] },
     { icon: "r", extensions: ["r"] },
     { icon: "rails", extensions: [] },
-    { icon: "react", extensions: ["jsx"] },
+    { icon: "react", extensions: ["jsx", "tsx"] },
     { icon: "ruby", extensions: ["rb"] },
     { icon: "rust", extensions: ["rs"] },
     { icon: "sass", extensions: ["sass"] },


### PR DESCRIPTION
The extension `.tsx` is the typescript equivalent to `.jsx`. It should be supported as well! 

Right here I added it as an alias to `.jsx` but it would be better to give  `.tsx` an alternate color from `.jsx`

One thing to note:
`.js` icon is yellow.
`.ts` icon is **blue**.
`.jsx` icon is **blue**.
`.tsx` icon is ???

Perhaps `.jsx` become yellow, `.tsx` becomes blue? Seems more idiomatic to me.