### PR TITLE
Remove headlines in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-##Instruction Template
+_**Instruction Template**_
 
 **THIS IS AN EXAMPLE TEMPLATE**
 
@@ -10,19 +10,19 @@
 
 **Thanks :smile:**
 
-###Checklist:
+**Checklist:**
 - [ ] I'm using Visual Studio Code Version [1.x.x] [Stable/Insider]
 - [ ] I'm using the extension version [1.x.x]
 - [ ] I've regarded to the (FAQ)[https://github.com/robertohuertasm/vscode-icons/blob/master/README.md#faqs] and they did not help.
 - [ ] My system is: [OS] [Arch]
 - [ ] I'm sure this issue is not a *duplicate*?
 
-###Description:
+**Description:**
 [short description of the bug, enhancement or feature request]
 
-###Steps to reproduce:
+**Steps to reproduce:**
 1. First step
-2. Second
+2. Second step
 3. And you can count yourself, can't you?
 
 _Expected behaviour:_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
-######Fixes #[ISSUE]
+***Fixes #[ISSUE]***
 
-####Changes proposed:
+**Changes proposed:**
 * [ ] Add
 * [ ] Prepare
 * [ ] Delete
 * [ ] Fix
 
-###Things I've done:
+**Things I've done:**
 * [ ] I've pulled the latest master branch
 * [ ] I've run `npm install` to install all the dependenies
 * [ ] I've checked my code, it is clean.
@@ -14,3 +14,5 @@
 * [ ] My pull request fixes an issue, I referenced the issue.
 * [ ] My pull request is not too big, otherwise I've already squashed it.
 * [ ] I've run `npm run build` to build the extension. (If I had done something with the extension.)
+
+[short comment]


### PR DESCRIPTION
***Fixes #134 second time***

**Changes proposed:**
* [ ] Add
* [ ] Prepare
* [ ] Delete
* [X] Fix

**Things I've done:**
* [X] I've pulled the latest master branch
* [ ] I've run `npm install` to install all the dependenies
* [X] I've checked my code, it is clean.
* [ ] I've run ESLint.
* [X] My pull request fixes an issue, I referenced the issue.
* [X] My pull request is not too big, otherwise I've already squashed it.
* [ ] I've run `npm run build` to build the extension. (If I had done something with the extension.)

looks like headlines aren't supported
