### PR TITLE
support `.markdown` for Markdown files

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -66,7 +66,7 @@ exports.extensions = {
     { icon: 'lisp', extensions: ['bil'] },
     { icon: 'lsl', extensions: ['lsl'] },
     { icon: 'lua', extensions: ['lua'] },
-    { icon: 'markdown', extensions: ['md'] },
+    { icon: 'markdown', extensions: ['md', 'markdown'] },
     { icon: 'marko', extensions: ['marko'] },
     { icon: 'markojs', extensions: ['.marko.js'], special: 'js' },
     { icon: 'markup', extensions: [] },


### PR DESCRIPTION
some repos e.g https://github.com/google/WebFundamentals use `.markdown` for markdown files.
and this is what [John Gruber endorses](http://daringfireball.net/linked/2014/01/08/markdown-extension).