### PR TITLE
Use the haxe icon for Haxe source files

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -55,7 +55,7 @@ exports.extensions = {
     { icon: 'haml', extensions: ['haml'] },
     { icon: 'handlebars', extensions: ['hbs', 'handlebars'] },
     { icon: 'haskell', extensions: ['has', 'hs', 'lhs', 'lit', 'gf'] },
-    { icon: 'haxe', extensions: ['hxml'] },
+    { icon: 'haxe', extensions: ['hx', 'hxml'] },
     { icon: 'html', extensions: ['htm', 'html'] },
     { icon: 'image', extensions: ['jpeg', 'jpg', 'gif', 'png', 'bmp'] },
     { icon: 'ionic', extensions: ['ionic'], special: 'project' },


### PR DESCRIPTION
`.hxml` are just config files for the Haxe compiler, source files use `.hx`.