### PR TITLE
Use the haxe icon for .hxp files

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -55,7 +55,7 @@ exports.extensions = {
     { icon: 'haml', extensions: ['haml'] },
     { icon: 'handlebars', extensions: ['hbs', 'handlebars'] },
     { icon: 'haskell', extensions: ['has', 'hs', 'lhs', 'lit', 'gf'] },
-    { icon: 'haxe', extensions: ['hx', 'hxml'] },
+    { icon: 'haxe', extensions: ['hx', 'hxml', 'hxp'] },
     { icon: 'html', extensions: ['htm', 'html'] },
     { icon: 'image', extensions: ['jpeg', 'jpg', 'gif', 'png', 'bmp'] },
     { icon: 'ionic', extensions: ['ionic'], special: 'project' },


### PR DESCRIPTION
Sort of a follow-up to #178. Lime, a very popular Haxe framework, has a project format that uses the `.hxp` file ending (most often used for the OpenFL framework that is built on top of it). Files are basically just Haxe source files with a different ending.

See http://www.openfl.org/learn/docs/command-line-tools/project-files/hxp-format/

It guess it would be even nicer if the Lime icon was used (https://github.com/openfl/lime/blob/develop/templates/default/icon.svg). But I'm not sure if you'd like to add that or not? Do you have any rules regarding adding new icons?