### PR TITLE
Add gitkeep as a Git extension

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -45,7 +45,7 @@ exports.extensions = {
     { icon: 'favicon', extensions: ['favicon'], special: 'ico' },
     { icon: 'font', extensions: ['woff', 'woff2', 'ttf', 'otf', 'eot', 'pfa', 'pfb', 'sfd'] },
     { icon: 'fsharp', extensions: ['fs', 'fsx', 'fsi'] },
-    { icon: 'git', extensions: ['gitattributes', 'gitignore', 'gitmodules'] },
+    { icon: 'git', extensions: ['gitattributes', 'gitignore', 'gitmodules', 'gitkeep'] },
     { icon: 'go', extensions: ['go'] },
     { icon: 'gradle', extensions: ['gradle'] },
     { icon: 'graphviz', extensions: [] },


### PR DESCRIPTION
.gitkeep isn't an official Git feature, but a fairly common naming convention (see http://stackoverflow.com/questions/7229885/what-are-the-differences-between-gitignore-and-gitkeep).

Btw, GitHub supports squashing commits to avoid the merge commit (just an fyi, it's a matter of preference).