### PR TITLE
Use the OCaml icon for .merlin

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -85,7 +85,7 @@ exports.extensions = {
     { icon: 'npm', extensions: ['npmignore'] },
     { icon: 'npm', extensions: ['package'], special: 'json' },
     { icon: 'nunjucks', extensions: ['njk', 'nunjucks', 'nunjs', 'nunj', 'njs', 'nj'] },
-    { icon: 'ocaml', extensions: ['cma', 'cmi', 'ml', 'mly', 'ocamlmakefile'] },
+    { icon: 'ocaml', extensions: ['cma', 'cmi', 'ml', 'mly', 'ocamlmakefile', 'merlin'] },
     { icon: 'perl', extensions: ['perl'] },
     { icon: 'php', extensions: ['php', 'php1', 'php2', 'php3', 'php4', 'php5', 'php6', 'phps', 'phpsa', 'phpt'] },
     { icon: 'procfile', extensions: ['procfile'] },


### PR DESCRIPTION
.merlin is a config file for https://github.com/the-lambda-church/merlin. Doesn't look like it has a logo of its own,, so it makes sense to just use the OCaml one I guess.