### PR TITLE
Adding config icon for config files and binary for pdb

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -10,7 +10,7 @@ exports.extensions = {
     { icon: 'assembly', extensions: ['s', 'asm'] },
     { icon: 'autohotkey', extensions: ['ahk'] },
     { icon: 'babel', extensions: ['babelrc'] },
-    { icon: 'binary', extensions: ['bin', 'o', 'a', 'exe', 'obj', 'lib', 'dll', 'pyc', 'pyd', 'pyo', 'n'] }, // http://www.file-extensions.org/filetype/extension/name/binary-files
+    { icon: 'binary', extensions: ['bin', 'o', 'a', 'exe', 'obj', 'lib', 'dll', 'pyc', 'pyd', 'pyo', 'n', 'pdb'] }, // http://www.file-extensions.org/filetype/extension/name/binary-files
     { icon: 'blade', extensions: ['.blade.php'], special: 'php' },
     { icon: 'bower', extensions: ['bowerrc'] },
     { icon: 'bower', extensions: ['bower'], special: 'json' },
@@ -21,7 +21,7 @@ exports.extensions = {
     { icon: 'cheader', extensions: ['h'] },
     { icon: 'clojure', extensions: ['clojure', 'cjm', 'clj', 'cljs', 'cljc', 'edn'] },
     { icon: 'coffeescript', extensions: ['coffee'] },
-    { icon: 'config', extensions: ['env', 'ini', 'makefile'] },
+    { icon: 'config', extensions: ['env', 'ini', 'makefile', 'config'] },
     { icon: 'compass', extensions: [] },
     { icon: 'cs', extensions: ['cs'] },
     { icon: 'cshtml', extensions: ['cshtml'] },


### PR DESCRIPTION
**Changes proposed:**
* [x] Add

**Things I've done:**
* [x] I've pulled the latest master branch
* [x] I've run `npm install` to install all the dependenies
* [x] I've checked my code, it is clean.
* [ ] I've run ESLint.
* [ ] My pull request fixes an issue, I referenced the issue.
* [x] My pull request is not too big, otherwise I've already squashed it.
* [ ] I've run `npm run build` to build the extension. (If I had done something with the extension.)

For example web.config in .Net Core projects
Also .pdb files from .Net