### PR TITLE
Add support for Lime include.xml files

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -79,6 +79,7 @@ exports.extensions = {
     { icon: 'license', extensions: ['license'] },
     { icon: 'lisp', extensions: ['bil'] },
     { icon: 'lime', extensions: ['hxp'] },
+    { icon: 'lime', extensions: ['include.xml'], special: 'xml' },
     { icon: 'lsl', extensions: ['lsl'] },
     { icon: 'lua', extensions: ['lua'] },
     { icon: 'm', extensions: ['m'] },


### PR DESCRIPTION
include.xml is a file for Lime-based haxe libraries with additional configuration that is added to a project when the lib is included.