### PR TITLE
Use the key icon for .enc

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -78,7 +78,7 @@ exports.extensions = {
     { icon: 'julia', extensions: ['jl'] },
     { icon: 'log', extensions: ['log'] },
     { icon: 'less', extensions: ['less'] },
-    { icon: 'license', extensions: ['license'] },
+    { icon: 'license', extensions: ['license', 'enc'] },
     { icon: 'lisp', extensions: ['bil'] },
     { icon: 'lime', extensions: ['hxp'] },
     { icon: 'lime', extensions: ['include.xml'], special: 'xml' },


### PR DESCRIPTION
It's often used for encrypted key files (for instance deploy keys), so the icon seems fitting.