### PR TITLE
Use the VSCode icon for tasks.json

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -160,7 +160,7 @@ exports.extensions = {
     { icon: 'vbhtml', extensions: ['vbhtml'] },
     { icon: 'vbproj', extensions: ['vbproj'] },
     { icon: 'vue', extensions: ['vue'] },
-    { icon: 'vscode', extensions: ['vscodeignore', 'launch', 'jsconfig', 'tsconfig'], special: 'json' },
+    { icon: 'vscode', extensions: ['vscodeignore', 'launch', 'tasks', 'jsconfig', 'tsconfig'], special: 'json' },
     { icon: 'xml', extensions: ['xml', 'axml', 'xaml', 'pex'] },
     { icon: 'yaml', extensions: ['yml', 'yaml'] },
     { icon: 'zip', extensions: ['zip', 'rar', '7z', 'tar', 'gz', 'bzip2', 'xz', 'bz2'] }


### PR DESCRIPTION
There is also a `settings.json`, but I didn't add that because the name might be a little too generic, leading to files using the icon incorrectly... Perhaps it could check that these files (`launch.json`, `tasks.json`, `settings.json`) are within a `.vscode` folder somehow?

