### PR TITLE
adds "build" folder name for "dist" icon

### DIFF
--- a/src/build/supportedFolders.js
+++ b/src/build/supportedFolders.js
@@ -2,7 +2,7 @@
 exports.extensions = {
   supported: [
     { icon: 'bower', extensions: ['bower_components'] },
-    { icon: 'dist', extensions: ['dist', 'out', 'export'] },
+    { icon: 'dist', extensions: ['dist', 'out', 'export', 'build'] },
     { icon: 'git', extensions: ['git', 'github'] },
     { icon: 'haxelib', extensions: ['haxelib'] },
     { icon: 'node', extensions: ['node_modules'] },


### PR DESCRIPTION
**Changes proposed:**
* [x] Add

**Things I've done:**
* [x] I've pulled the latest master branch
* [x] I've run `npm install` to install all the dependenies
* [x] I've checked my code, it is clean.
* [ ] I've run ESLint.
* [ ] My pull request fixes an issue, I referenced the issue.
* [x] My pull request is not too big, otherwise I've already squashed it.
* [ ] I've run `npm run build` to build the extension. (If I had done something with the extension.)

[short comment]
in polymer-tools "dist" folder name is "build"