### PR TITLE
Fix gitlab-ci icon association

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -62,7 +62,7 @@ exports.extensions = {
     { icon: 'font', extensions: ['woff', 'woff2', 'ttf', 'otf', 'eot', 'pfa', 'pfb', 'sfd'] },
     { icon: 'fortran', extensions: ['f90', 'mod', 'f'] },
     { icon: 'git', extensions: ['.gitattributes', '.gitignore', '.gitmodules', '.gitkeep'], contribType: ctype.filename },
-    { icon: 'gitlab', extensions: ['gitlab-ci.yml'], contribType: ctype.filename },
+    { icon: 'gitlab', extensions: ['.gitlab-ci.yml'], contribType: ctype.filename },
     { icon: 'go', extensions: ['go'] },
     { icon: 'gradle', extensions: ['gradle'] },
     { icon: 'graphviz', extensions: [] },


### PR DESCRIPTION
***Fixes #404***

**Changes proposed:**
* [ ] Add
* [ ] Prepare
* [ ] Delete
* [x] Fix

**Things I've done:**
* [x] I've pulled the latest master branch.
* [ ] I've run `npm install` to install all the dependencies.
* [ ] I've run ESLint.
* [x] My pull request fixes an issue, I referenced the issue.
* [ ] I've run `npm run build` to build the extension.

GitLab CI filenames begin with a `.` Similar to the name `.travis.yml`, it is `.gitlab-ci.yml`.