### PR TITLE
add mdown as markdown file extension

### DIFF
--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -103,7 +103,7 @@ exports.extensions = {
     { icon: 'lsl', extensions: ['lsl'] },
     { icon: 'lua', extensions: ['lua'] },
     { icon: 'm', extensions: ['m'] },
-    { icon: 'markdown', extensions: ['md', 'markdown'] },
+    { icon: 'markdown', extensions: ['md', 'mdown', 'markdown'] },
     { icon: 'marko', extensions: ['marko'] },
     { icon: 'markojs', extensions: ['marko.js'] },
     { icon: 'markup', extensions: [] },


### PR DESCRIPTION
This PR adds `.mdown` to the markdown file extensions.

**Why?** I have a ton of `.mdown` files in one of my projects. I would rather not, but alas ... not the point.

**More?** Based on some quick googling there are [several other](http://superuser.com/questions/249436/file-extension-for-markdown-files) extensions for markdown files, but [not without some controversy](http://daringfireball.net/linked/2014/01/08/markdown-extension). Happy to add those too if you'd like.

