### PR TITLE
added '.exp' extension to tcl

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -1046,6 +1046,7 @@
     "svg": "_f_svg",
     "swift": "_f_swift",
     "tcl": "_f_tcl",
+    "exp": "_f_tcl",
     "tf": "_f_terraform",
     "terra": "_f_terraform",
     "test.js": "_f_testjs",

--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -170,7 +170,7 @@ exports.extensions = {
     { icon: 'storyboard', extensions: ['storyboard'] },
     { icon: 'svg', extensions: ['svg'] },
     { icon: 'swift', extensions: ['swift'] },
-    { icon: 'tcl', extensions: ['tcl'] },
+    { icon: 'tcl', extensions: ['tcl', 'exp'] },
     { icon: 'terraform', extensions: ['tf', 'terra'] },
     { icon: 'testjs', extensions: ['test.js', 'spec.js'] },
     { icon: 'testts', extensions: ['test.ts', 'spec.ts'] },


### PR DESCRIPTION
***Fixes #475***

**Changes proposed:**
* [x] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

**Things I've done:**
* [x] I've pulled the latest master branch.
* [x] I've run `npm install` to install all the dependencies.
* [ ] I've run ESLint. - *I'm not sure how to run eslint, and this is a tiny change*
* [x] My pull request fixes an issue, I referenced the issue.
* [x] I've run `npm run build` to build the extension.

This is for making .exp (expect) scripts show up with the tcl icon

