### PR TITLE
Refactored the build process.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,14 @@
         "code": 100
       }
     ],
-    "no-console": 0,
+    "no-console": [
+      1,
+      {
+        "allow": [
+          "error"
+        ]
+      }
+    ],
     "no-restricted-syntax": [
       0,
       "ForInStatement"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,13 @@
     "airbnb-base/legacy"
   ],
   "rules": {
+    "max-len": [
+      2,
+      {
+        "code": 100
+      }
+    ],
+    "no-console": 0,
     "no-restricted-syntax": [
       0,
       "ForInStatement"

--- a/icons.json
+++ b/icons.json
@@ -69,6 +69,12 @@
     "_fd_locale_open": {
       "iconPath": "./icons/folder_type_locale_opened@2x.png"
     },
+    "_fd_meteor": {
+      "iconPath": "./icons/folder_type_meteor@2x.png"
+    },
+    "_fd_meteor_open": {
+      "iconPath": "./icons/folder_type_meteor_opened@2x.png"
+    },
     "_fd_node": {
       "iconPath": "./icons/folder_type_node@2x.png"
     },
@@ -80,12 +86,6 @@
     },
     "_fd_nuget_open": {
       "iconPath": "./icons/folder_type_nuget_opened@2x.png"
-    },
-    "_fd_meteor": {
-      "iconPath": "./icons/folder_type_meteor@2x.png"
-    },
-    "_fd_meteor_open": {
-      "iconPath": "./icons/folder_type_meteor_opened@2x.png"
     },
     "_fd_sass": {
       "iconPath": "./icons/folder_type_sass@2x.png"
@@ -144,6 +144,9 @@
     "_f_angular": {
       "iconPath": "./icons/file_type_angular@2x.png"
     },
+    "_f_ansible": {
+      "iconPath": "./icons/file_type_ansible@2x.png"
+    },
     "_f_apache": {
       "iconPath": "./icons/file_type_apache@2x.png"
     },
@@ -155,9 +158,6 @@
     },
     "_f_appveyor": {
       "iconPath": "./icons/file_type_appveyor@2x.png"
-    },
-    "_f_ansible": {
-      "iconPath": "./icons/file_type_ansible@2x.png"
     },
     "_f_asp": {
       "iconPath": "./icons/file_type_asp@2x.png"
@@ -189,9 +189,6 @@
     "_f_bundler": {
       "iconPath": "./icons/file_type_bundler@2x.png"
     },
-    "_f_cpp": {
-      "iconPath": "./icons/file_type_cpp@2x.png"
-    },
     "_f_c": {
       "iconPath": "./icons/file_type_c@2x.png"
     },
@@ -219,14 +216,17 @@
     "_f_coffeescript": {
       "iconPath": "./icons/file_type_coffeescript@2x.png"
     },
-    "_f_config": {
-      "iconPath": "./icons/file_type_config@2x.png"
-    },
     "_f_compass": {
       "iconPath": "./icons/file_type_compass@2x.png"
     },
     "_f_composer": {
       "iconPath": "./icons/file_type_composer@2x.png"
+    },
+    "_f_config": {
+      "iconPath": "./icons/file_type_config@2x.png"
+    },
+    "_f_cpp": {
+      "iconPath": "./icons/file_type_cpp@2x.png"
     },
     "_f_cs": {
       "iconPath": "./icons/file_type_cs@2x.png"
@@ -300,14 +300,14 @@
     "_f_flow": {
       "iconPath": "./icons/file_type_flow@2x.png"
     },
-    "_f_fsharp": {
-      "iconPath": "./icons/file_type_fsharp@2x.png"
-    },
     "_f_font": {
       "iconPath": "./icons/file_type_font@2x.png"
     },
     "_f_fortran": {
       "iconPath": "./icons/file_type_fortran@2x.png"
+    },
+    "_f_fsharp": {
+      "iconPath": "./icons/file_type_fsharp@2x.png"
     },
     "_f_git": {
       "iconPath": "./icons/file_type_git@2x.png"
@@ -408,11 +408,11 @@
     "_f_license": {
       "iconPath": "./icons/file_type_license@2x.png"
     },
-    "_f_lisp": {
-      "iconPath": "./icons/file_type_lisp@2x.png"
-    },
     "_f_lime": {
       "iconPath": "./icons/file_type_lime@2x.png"
+    },
+    "_f_lisp": {
+      "iconPath": "./icons/file_type_lisp@2x.png"
     },
     "_f_log": {
       "iconPath": "./icons/file_type_log@2x.png"
@@ -438,11 +438,11 @@
     "_f_markup": {
       "iconPath": "./icons/file_type_markup@2x.png"
     },
-    "_f_matlab": {
-      "iconPath": "./icons/file_type_matlab@2x.png"
-    },
     "_f_masterpage": {
       "iconPath": "./icons/file_type_masterpage@2x.png"
+    },
+    "_f_matlab": {
+      "iconPath": "./icons/file_type_matlab@2x.png"
     },
     "_f_mustache": {
       "iconPath": "./icons/file_type_mustache@2x.png"
@@ -483,9 +483,6 @@
     "_f_perl": {
       "iconPath": "./icons/file_type_perl@2x.png"
     },
-    "_f_poedit": {
-      "iconPath": "./icons/file_type_poedit@2x.png"
-    },
     "_f_photoshop": {
       "iconPath": "./icons/file_type_photoshop@2x.png"
     },
@@ -498,17 +495,20 @@
     "_f_plantuml": {
       "iconPath": "./icons/file_type_plantuml@2x.png"
     },
-    "_f_procfile": {
-      "iconPath": "./icons/file_type_procfile@2x.png"
-    },
-    "_f_prolog": {
-      "iconPath": "./icons/file_type_prolog@2x.png"
+    "_f_poedit": {
+      "iconPath": "./icons/file_type_poedit@2x.png"
     },
     "_f_postcss": {
       "iconPath": "./icons/file_type_postcss@2x.png"
     },
     "_f_powershell": {
       "iconPath": "./icons/file_type_powershell@2x.png"
+    },
+    "_f_procfile": {
+      "iconPath": "./icons/file_type_procfile@2x.png"
+    },
+    "_f_prolog": {
+      "iconPath": "./icons/file_type_prolog@2x.png"
     },
     "_f_protobuf": {
       "iconPath": "./icons/file_type_protobuf@2x.png"
@@ -603,14 +603,14 @@
     "_f_sss": {
       "iconPath": "./icons/file_type_sss@2x.svg"
     },
+    "_f_storyboard": {
+      "iconPath": "./icons/file_type_storyboard@2x.png"
+    },
     "_f_stylelint": {
       "iconPath": "./icons/file_type_stylelint@2x.png"
     },
     "_f_stylus": {
       "iconPath": "./icons/file_type_stylus@2x.png"
-    },
-    "_f_storyboard": {
-      "iconPath": "./icons/file_type_storyboard@2x.png"
     },
     "_f_svg": {
       "iconPath": "./icons/file_type_svg@2x.png"
@@ -735,9 +735,9 @@
     "less": "_fd_less",
     "locale": "_fd_locale",
     "locales": "_fd_locale",
+    ".meteor": "_fd_meteor",
     "node_modules": "_fd_node",
     ".nuget": "_fd_nuget",
-    ".meteor": "_fd_meteor",
     "sass": "_fd_sass",
     "scss": "_fd_sass",
     "script": "_fd_script",
@@ -774,9 +774,9 @@
     "less": "_fd_less_open",
     "locale": "_fd_locale_open",
     "locales": "_fd_locale_open",
+    ".meteor": "_fd_meteor_open",
     "node_modules": "_fd_node_open",
     ".nuget": "_fd_nuget_open",
-    ".meteor": "_fd_meteor_open",
     "sass": "_fd_sass_open",
     "scss": "_fd_sass_open",
     "script": "_fd_script_open",
@@ -799,9 +799,9 @@
   "fileExtensions": {
     "as": "_f_actionscript",
     "ai": "_f_ai",
+    "ansible": "_f_ansible",
     "apib": "_f_apib",
     "app": "_f_applescript",
-    "ansible": "_f_ansible",
     "asp": "_f_asp",
     "aspx": "_f_aspx",
     "ascx": "_f_aspx",
@@ -828,10 +828,6 @@
     "cmxa": "_f_binary",
     "cmi": "_f_binary",
     "blade.php": "_f_blade",
-    "cpp": "_f_cpp",
-    "hpp": "_f_cpp",
-    "cc": "_f_cpp",
-    "cxx": "_f_cpp",
     "c": "_f_c",
     "cake": "_f_cake",
     "cfm": "_f_cfm",
@@ -855,6 +851,10 @@
     "config": "_f_config",
     "conf": "_f_config",
     "cfg": "_f_config",
+    "cpp": "_f_cpp",
+    "hpp": "_f_cpp",
+    "cc": "_f_cpp",
+    "cxx": "_f_cpp",
     "cs": "_f_cs",
     "csx": "_f_cs",
     "cshtml": "_f_cshtml",
@@ -887,9 +887,6 @@
     "swc": "_f_flash",
     "sol": "_f_flash",
     "js.flow": "_f_flow",
-    "fs": "_f_fsharp",
-    "fsx": "_f_fsharp",
-    "fsi": "_f_fsharp",
     "woff": "_f_font",
     "woff2": "_f_font",
     "ttf": "_f_font",
@@ -901,6 +898,9 @@
     "f90": "_f_fortran",
     "mod": "_f_fortran",
     "f": "_f_fortran",
+    "fs": "_f_fsharp",
+    "fsx": "_f_fsharp",
+    "fsi": "_f_fsharp",
     "go": "_f_go",
     "gradle": "_f_gradle",
     "gql": "_f_graphql",
@@ -941,8 +941,8 @@
     "kt": "_f_kotlin",
     "less": "_f_less",
     "enc": "_f_license",
-    "bil": "_f_lisp",
     "hxp": "_f_lime",
+    "bil": "_f_lisp",
     "log": "_f_log",
     "lsl": "_f_lsl",
     "lua": "_f_lua",
@@ -952,6 +952,7 @@
     "markdown": "_f_markdown",
     "marko": "_f_marko",
     "marko.js": "_f_markojs",
+    "master": "_f_masterpage",
     "fig": "_f_matlab",
     "mat": "_f_matlab",
     "mex": "_f_matlab",
@@ -967,7 +968,6 @@
     "smv": "_f_matlab",
     "tikz": "_f_matlab",
     "xvc": "_f_matlab",
-    "master": "_f_masterpage",
     "mustache": "_f_mustache",
     "mst": "_f_mustache",
     "nim": "_f_nim",
@@ -994,8 +994,6 @@
     "patch": "_f_patch",
     "pdf": "_f_pdf",
     "perl": "_f_perl",
-    "po": "_f_poedit",
-    "mo": "_f_poedit",
     "psd": "_f_photoshop",
     "php": "_f_php",
     "php1": "_f_php",
@@ -1013,14 +1011,16 @@
     "plantuml": "_f_plantuml",
     "iuml": "_f_plantuml",
     "puml": "_f_plantuml",
-    "P": "_f_prolog",
-    "pl": "_f_prolog",
-    "pro": "_f_prolog",
+    "po": "_f_poedit",
+    "mo": "_f_poedit",
     "pcss": "_f_postcss",
     "postcss": "_f_postcss",
     "ps1": "_f_powershell",
     "psm1": "_f_powershell",
     "psd1": "_f_powershell",
+    "P": "_f_prolog",
+    "pl": "_f_prolog",
+    "pro": "_f_prolog",
     "proto": "_f_protobuf",
     "epp": "_f_puppet",
     "pp": "_f_puppet",
@@ -1059,8 +1059,8 @@
     "sqlite3": "_f_sqlite",
     "db3": "_f_sqlite",
     "sss": "_f_sss",
-    "styl": "_f_stylus",
     "storyboard": "_f_storyboard",
+    "styl": "_f_stylus",
     "svg": "_f_svg",
     "swift": "_f_swift",
     "tcl": "_f_tcl",
@@ -1121,10 +1121,10 @@
     "gemfile": "_f_bundler",
     "gemfile.lock": "_f_bundler",
     "codeclimate.yml": "_f_codeclimate",
-    "makefile": "_f_config",
-    ".env.example": "_f_config",
     "composer.json": "_f_composer",
     "composer.lock": "_f_composer",
+    "makefile": "_f_config",
+    ".env.example": "_f_config",
     ".csslintrc": "_f_csslint",
     "dockerfile": "_f_docker",
     ".dockerignore": "_f_docker",

--- a/package.json
+++ b/package.json
@@ -1,29 +1,53 @@
 {
-    "name": "vscode-icons",
-    "displayName": "vscode-icons",
-    "description": "Icons for Visual Studio Code",
-    "version": "4.0.5",
-    "publisher": "robertohuertasm",
-    "license": "MIT",
-    "author": {
-        "email": "roberto.huertas@outlook.com",
-        "name": "Roberto Huertas",
-        "url": "http://codecoding.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/robertohuertasm/vscode-icons"
-    },
-    "bugs": {
-        "url": "https://github.com/robertohuertasm/vscode-icons/issues",
-        "email": "roberto.huertas@outlook.com"
-    },
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other",
-        "Themes"
+  "name": "vscode-icons",
+  "displayName": "vscode-icons",
+  "description": "Icons for Visual Studio Code",
+  "version": "4.0.5",
+  "publisher": "robertohuertasm",
+  "license": "MIT",
+  "author": {
+    "email": "roberto.huertas@outlook.com",
+    "name": "Roberto Huertas",
+    "url": "http://codecoding.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robertohuertasm/vscode-icons"
+  },
+  "bugs": {
+    "url": "https://github.com/robertohuertasm/vscode-icons/issues",
+    "email": "roberto.huertas@outlook.com"
+  },
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": [
+    "Other",
+    "Themes"
+  ],
+  "keywords": [
+    "icon-theme",
+    "theme",
+    "icons",
+    "vscode-icons"
+  ],
+  "preview": true,
+  "homepage": "https://github.com/robertohuertasm/vscode-icons",
+  "icon": "images/logo.png",
+  "galleryBanner": {
+    "color": "#ffdd00"
+  },
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./dist/extension",
+  "contributes": {
+    "iconThemes": [
+      {
+        "id": "vscode-icons",
+        "label": "VSCode Icons",
+        "path": "./icons.json"
+      }
     ],
     "configuration": {
       "title": "vscode-icons configuration",
@@ -39,8 +63,8 @@
   "scripts": {
     "build": "node ./src/build/build.js",
     "example": "node ./src/build/example.js ",
-    "postinstall": "node ./node_modules/vscode/bin/install",
-    "lint": "node ./node_modules/eslint/bin/eslint src"
+    "lint": "node ./node_modules/eslint/bin/eslint src",
+    "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
     "eslint": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -1,82 +1,83 @@
 {
-    "name": "vscode-icons",
-    "displayName": "vscode-icons",
-    "description": "Icons for Visual Studio Code",
-    "version": "4.0.4",
-    "publisher": "robertohuertasm",
-    "license": "MIT",
-    "author": {
-        "email": "roberto.huertas@outlook.com",
-        "name": "Roberto Huertas",
-        "url": "http://codecoding.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/robertohuertasm/vscode-icons"
-    },
-    "bugs": {
-        "url": "https://github.com/robertohuertasm/vscode-icons/issues",
-        "email": "roberto.huertas@outlook.com"
-    },
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other",
-        "Themes"
+  "name": "vscode-icons",
+  "displayName": "vscode-icons",
+  "description": "Icons for Visual Studio Code",
+  "version": "4.0.4",
+  "publisher": "robertohuertasm",
+  "license": "MIT",
+  "author": {
+    "email": "roberto.huertas@outlook.com",
+    "name": "Roberto Huertas",
+    "url": "http://codecoding.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robertohuertasm/vscode-icons"
+  },
+  "bugs": {
+    "url": "https://github.com/robertohuertasm/vscode-icons/issues",
+    "email": "roberto.huertas@outlook.com"
+  },
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": [
+    "Other",
+    "Themes"
+  ],
+  "keywords": [
+    "icon-theme",
+    "theme",
+    "icons",
+    "vscode-icons"
+  ],
+  "preview": true,
+  "homepage": "https://github.com/robertohuertasm/vscode-icons",
+  "icon": "images/logo.png",
+  "galleryBanner": {
+    "color": "#ffdd00"
+  },
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./dist/extension",
+  "contributes": {
+    "iconThemes": [
+      {
+        "id": "vscode-icons",
+        "label": "VSCode Icons",
+        "path": "./icons.json"
+      }
     ],
-    "keywords": [
-        "icon-theme",
-        "theme",
-        "icons",
-        "vscode-icons"
-    ],
-    "preview": true,
-    "homepage": "https://github.com/robertohuertasm/vscode-icons",
-    "icon": "images/logo.png",
-    "galleryBanner": {
-        "color": "#ffdd00"
-    },
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./dist/extension",
-    "contributes": {
-        "iconThemes": [
-            {
-                "id": "vscode-icons",
-                "label": "VSCode Icons",
-                "path": "./icons.json"
-            }
-        ],
-        "configuration": {
-            "title": "vscode-icons configuration",
-            "properties": {
-                "vsicons.dontShowNewVersionMessage": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If set to true the new version message won't be shown anymore."
-                }
-            }
+    "configuration": {
+      "title": "vscode-icons configuration",
+      "properties": {
+        "vsicons.dontShowNewVersionMessage": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true the new version message won't be shown anymore."
         }
-    },
-    "scripts": {
-        "build": "node ./src/build/build.js",
-        "example": "node ./src/build/example.js ",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "eslint": "^2.10.2",
-        "eslint-config-airbnb": "^9.0.1",
-        "eslint-plugin-import": "^1.8.0",
-        "eslint-plugin-jsx-a11y": "^1.2.0",
-        "eslint-plugin-react": "^5.1.1",
-        "ncp": "^2.0.0",
-        "underscore": "^1.8.3",
-        "vscode": "^1.0.0"
-    },
-    "dependencies": {
-        "open": "0.0.5",
-        "semver": "^5.3.0"
+      }
     }
+  },
+  "scripts": {
+    "build": "node ./src/build/build.js",
+    "example": "node ./src/build/example.js ",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "lint": "node ./node_modules/eslint/bin/eslint src"
+  },
+  "devDependencies": {
+    "eslint": "^2.13.1",
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-jsx-a11y": "^1.2.0",
+    "eslint-plugin-react": "^5.1.1",
+    "ncp": "^2.0.0",
+    "underscore": "^1.8.3",
+    "vscode": "^1.0.0"
+  },
+  "dependencies": {
+    "open": "0.0.5",
+    "semver": "^5.3.0"
+  }
 }

--- a/src/build/build.js
+++ b/src/build/build.js
@@ -16,6 +16,6 @@ ncp('./src/dev', outDir, function (err) {
     console.error(err);
     return;
   }
-  console.log('Build completed!');
+  console.log('Build completed!'); //eslint-disable-line
 });
 

--- a/src/build/build.js
+++ b/src/build/build.js
@@ -1,16 +1,21 @@
 var ncp = require('ncp').ncp;
 var iconGenerator = require('./iconGenerator');
 
+var outDir = './dist';
+
 // generating icons.json
-iconGenerator.generate();
+// The function takes as second argument the directory where
+// we want the file to be placed.
+// Default directory is the 'root' directory
+iconGenerator.generate('icons.json');
 
 // moving to dist
 ncp.limit = 16;
-ncp('./src/dev', './dist', function (err) {
+ncp('./src/dev', outDir, function (err) {
   if (err) {
-    console.error(err); // eslint-disable-line
+    console.error(err);
     return;
   }
-  console.log('Build completed!'); // eslint-disable-line
+  console.log('Build completed!');
 });
 

--- a/src/build/exampleGenerator.js
+++ b/src/build/exampleGenerator.js
@@ -68,7 +68,7 @@ function buildFiles(icons) {
     var fileName = fileNames[icon];
 
     if (!fileName) {
-      console.log('Unsupported file: ' + icon);
+      console.error('Unsupported file: ' + icon);
       return;
     }
 
@@ -76,7 +76,7 @@ function buildFiles(icons) {
       fs.writeFileSync(fileName, null);
       console.log('Example file for \'' + icon + '\' successfully created!');
     } catch (error) {
-      console.log('Something went wrong while creating the file for \'' + icon + '\' :\n', error);
+      console.error('Something went wrong while creating the file for \'' + icon + '\' :\n', error);
     }
   });
 }
@@ -91,7 +91,7 @@ function buildFolders(icons) {
     var dirName = folderNames[icon];
 
     if (!dirName) {
-      console.log('Unsupported folder: ' + icon);
+      console.error('Unsupported folder: ' + icon);
       return;
     }
 
@@ -99,7 +99,8 @@ function buildFolders(icons) {
       fs.mkdirSync(dirName);
       console.log('Example folder for \'' + icon + '\' successfully created!');
     } catch (error) {
-      console.log('Something went wrong while creating the folder for \'' + icon + '\' :\n', error);
+      console.error('Something went wrong while creating the folder for \''
+        + icon + '\' :\n', error);
     }
   });
 }
@@ -149,13 +150,13 @@ function assertFlags(args) {
   var supportedFlagsMsg = 'Supported flags are ' + supportedFlags.join(', ') + '.';
 
   if (args.length <= 2) {
-    console.log('Please provide a valid flag. ' + supportedFlagsMsg);
+    console.error('Please provide a valid flag. ' + supportedFlagsMsg);
     return true;
   }
 
   if (args.length > 2) {
     if (supportedFlags.indexOf(args[2]) === -1) {
-      console.log(supportedFlagsMsg);
+      console.error(supportedFlagsMsg);
       return true;
     }
   }

--- a/src/build/exampleGenerator.js
+++ b/src/build/exampleGenerator.js
@@ -25,12 +25,18 @@ var fileNames = files.supported.reduce(function (init, current) {
   return obj;
 }, {});
 
-function deleteFolderRecursively(path) {
+
+/**
+ * Deletes a directory and all subdirectories
+ *
+ * @param {any} path The directory's path
+ */
+function deleteDirectoryRecursively(path) {
   if (fs.existsSync(path)) {
     fs.readdirSync(path).forEach(function (file) {
       var curPath = path + '/' + file;
       if (fs.lstatSync(curPath).isDirectory()) { // recurse
-        deleteFolderRecursively(curPath);
+        deleteDirectoryRecursively(curPath);
       } else { // delete file
         fs.unlinkSync(curPath);
       }
@@ -39,52 +45,75 @@ function deleteFolderRecursively(path) {
   }
 }
 
-function createFolder(dirName) {
-  deleteFolderRecursively(dirName);
+
+/**
+ * Creates a directory if it doesn't exists.
+ *
+ * @param {any} dirName The directory name
+ */
+function createDirectory(dirName) {
+  deleteDirectoryRecursively(dirName);
   fs.mkdirSync(dirName);
   process.chdir(dirName);
 }
 
+
+/**
+ * Builds the files.
+ *
+ * @param {any} icons The icons names to build examples of
+ */
 function buildFiles(icons) {
   icons.forEach(function (icon) {
     var fileName = fileNames[icon];
 
     if (!fileName) {
-      console.log('Unsupported file: ' + icon); // eslint-disable-line
+      console.log('Unsupported file: ' + icon);
       return;
     }
 
     try {
       fs.writeFileSync(fileName, null);
-      console.log('Example file for \'' + icon + '\' successfully created!'); // eslint-disable-line
+      console.log('Example file for \'' + icon + '\' successfully created!');
     } catch (error) {
-      console.log('Something went wrong while creating the file for \'' + icon + '\' :\n', error); // eslint-disable-line
+      console.log('Something went wrong while creating the file for \'' + icon + '\' :\n', error);
     }
   });
 }
 
+/**
+ * Builds the folders.
+ *
+ * @param {any} icons The icons names to build examples of
+ */
 function buildFolders(icons) {
   icons.forEach(function (icon) {
     var dirName = folderNames[icon];
 
     if (!dirName) {
-      console.log('Unsupported folder: ' + icon); // eslint-disable-line
+      console.log('Unsupported folder: ' + icon);
       return;
     }
 
     try {
       fs.mkdirSync(dirName);
-      console.log('Example folder for \'' + icon + '\' successfully created!'); // eslint-disable-line
+      console.log('Example folder for \'' + icon + '\' successfully created!');
     } catch (error) {
-      console.log('Something went wrong while creating the folder for \'' + icon + '\' :\n', error); // eslint-disable-line
+      console.log('Something went wrong while creating the folder for \'' + icon + '\' :\n', error);
     }
   });
 }
 
+/**
+ * Builds the examples.
+ *
+ * @param {any} flag The flag
+ * @param {any} icons The icons names to build examples of
+ */
 function buildExample(flag, icons) {
   var currentDir = process.cwd();
 
-  createFolder('examples');
+  createDirectory('examples');
 
   if (flag === 'files') {
     if (!icons.length) {
@@ -110,17 +139,23 @@ function buildExample(flag, icons) {
   process.chdir(currentDir);
 }
 
+/**
+ * Asserts the arguments
+ *
+ * @param {any} args The arguments
+ * @returns 'true' if the check fails, otherwise 'false'
+ */
 function assertFlags(args) {
   var supportedFlagsMsg = 'Supported flags are ' + supportedFlags.join(', ') + '.';
 
   if (args.length <= 2) {
-    console.log('Please provide a valid flag. ' + supportedFlagsMsg); // eslint-disable-line
+    console.log('Please provide a valid flag. ' + supportedFlagsMsg);
     return true;
   }
 
   if (args.length > 2) {
     if (supportedFlags.indexOf(args[2]) === -1) {
-      console.log(supportedFlagsMsg); // eslint-disable-line
+      console.log(supportedFlagsMsg);
       return true;
     }
   }
@@ -128,6 +163,12 @@ function assertFlags(args) {
   return false;
 }
 
+/**
+ * Generates examples for the icons.
+ *
+ * @param {any} args The arguments
+ * @returns
+ */
 function generate(args) {
   var icons = [];
 

--- a/src/build/exampleGenerator.js
+++ b/src/build/exampleGenerator.js
@@ -74,7 +74,7 @@ function buildFiles(icons) {
 
     try {
       fs.writeFileSync(fileName, null);
-      console.log('Example file for \'' + icon + '\' successfully created!');
+      console.log('Example file for \'' + icon + '\' successfully created!'); //eslint-disable-line
     } catch (error) {
       console.error('Something went wrong while creating the file for \'' + icon + '\' :\n', error);
     }
@@ -97,7 +97,7 @@ function buildFolders(icons) {
 
     try {
       fs.mkdirSync(dirName);
-      console.log('Example folder for \'' + icon + '\' successfully created!');
+      console.log('Example folder for \'' + icon + '\' successfully created!'); //eslint-disable-line
     } catch (error) {
       console.error('Something went wrong while creating the folder for \''
         + icon + '\' :\n', error);

--- a/src/build/iconGenerator.js
+++ b/src/build/iconGenerator.js
@@ -32,35 +32,40 @@ function buildJsonStructure(iconsFolderBasePath) {
 
   return {
     /**   folders section   **/
-    folders: folders.supported.reduce(function (old, current) {
-      var defs = old.defs;
-      var names = old.names;
-      var icon = current.icon;
-      var iconFolderType = 'folder_type_' + icon;
-      var folderPath = iconsFolderBasePath + iconFolderType;
-      var openFolderPath = folderPath + '_opened';
-      var iconFolderDefinition = '_fd_' + icon;
-      var iconOpenFolderDefinition = iconFolderDefinition + '_open';
-      var iconFileExtension = current.svg ? '.svg' : '.png';
+    folders: _.sortBy(folders.supported, function (item) {
+      return item.icon;
+    })
+      .reduce(function (old, current) {
+        var defs = old.defs;
+        var names = old.names;
+        var icon = current.icon;
+        var iconFolderType = 'folder_type_' + icon;
+        var folderPath = iconsFolderBasePath + iconFolderType;
+        var openFolderPath = folderPath + '_opened';
+        var iconFolderDefinition = '_fd_' + icon;
+        var iconOpenFolderDefinition = iconFolderDefinition + '_open';
+        var iconFileExtension = current.svg ? '.svg' : '.png';
 
-      defs[iconFolderDefinition] = {
-        iconPath: folderPath + suffix + iconFileExtension
-      };
-      defs[iconOpenFolderDefinition] = {
-        iconPath: openFolderPath + suffix + iconFileExtension
-      };
+        defs[iconFolderDefinition] = {
+          iconPath: folderPath + suffix + iconFileExtension
+        };
+        defs[iconOpenFolderDefinition] = {
+          iconPath: openFolderPath + suffix + iconFileExtension
+        };
 
-      current.extensions.forEach(function (extension) {
-        var key = current.dot ? '.' + extension : extension;
-        names.folderNames[key] = iconFolderDefinition;
-        names.folderNamesExpanded[key] = iconOpenFolderDefinition;
-      });
+        current.extensions.forEach(function (extension) {
+          var key = current.dot ? '.' + extension : extension;
+          names.folderNames[key] = iconFolderDefinition;
+          names.folderNamesExpanded[key] = iconOpenFolderDefinition;
+        });
 
-      return old;
-    }, { defs: {}, names: { folderNames: {}, folderNamesExpanded: {} } }),
+        return old;
+      }, { defs: {}, names: { folderNames: {}, folderNamesExpanded: {} } }),
 
     /**   files section   **/
-    files: _.uniq(files.supported, true)
+    files: _.uniq(_.sortBy(files.supported, function (item) {
+      return item.icon;
+    }), true)
       .reduce(function (old, current) {
         var defs = old.defs;
         var names = old.names;

--- a/src/build/iconGenerator.js
+++ b/src/build/iconGenerator.js
@@ -161,7 +161,7 @@ function writeJsonToFile(json, iconsFilename, outDir) {
     }
 
     fs.writeFileSync(outDir + iconsFilename, JSON.stringify(json, null, 2));
-    console.log('Icon contribution file successfully generated!');
+    console.log('Icon contribution file successfully generated!'); //eslint-disable-line
   } catch (error) {
     console.error('Something went wrong while generating the icon contribution file:', error);
   }
@@ -184,7 +184,7 @@ function updatePackageJson(newIconThemesPath) {
 
   try {
     fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
-    console.log('package.json updated');
+    console.log('package.json updated'); //eslint-disable-line
   } catch (err) {
     console.error(err);
   }

--- a/src/build/iconGenerator.js
+++ b/src/build/iconGenerator.js
@@ -1,43 +1,17 @@
 var fs = require('fs');
+var path = require('path');
 var _ = require('underscore');
 var files = require('./supportedExtensions').extensions;
 var folders = require('./supportedFolders').extensions;
 var ctype = require('./contribTypes');
 
-var f = folders.supported.reduce(function (old, current) {
-  var defs = old.defs;
-  var names = old.names;
 
-  var icon = current.icon;
-  defs['_fd_' + icon] = {
-    iconPath: './icons/folder_type_' + icon + '@2x.' + (current.svg ? 'svg' : 'png')
-  };
-  defs['_fd_' + icon + '_open'] = {
-    iconPath: './icons/folder_type_' + icon + '_opened@2x.' + (current.svg ? 'svg' : 'png')
-  };
-
-  current.extensions.forEach(function (o) {
-    var key = current.dot ? '.' + o : o;
-    names.folders[key] = '_fd_' + current.icon;
-    names.foldersOpen[key] = '_fd_' + current.icon + '_open';
-  });
-
-  return old;
-}, { defs: {}, names: { folders: {}, foldersOpen: {} } });
-
-var folderNames = f.names;
-var folderDefs = f.defs;
-
-var fileDefs = _.uniq(_.map(files.supported, function (o) {
-  return { icon: o.icon, svg: o.svg };
-})).reduce(function (old, current) {
-  var oldObj = old;
-  oldObj['_f_' + current.icon] = {
-    iconPath: './icons/file_type_' + current.icon + '@2x.' + (current.svg ? 'svg' : 'png')
-  };
-  return oldObj;
-}, {});
-
+/**
+ * Removes the first dot from the text.
+ *
+ * @param {any} txt The text
+ * @returns A text without leading dot
+ */
 function removeFirstDot(txt) {
   if (txt.indexOf('.') === 0) {
     return txt.substring(1, txt.length);
@@ -45,37 +19,93 @@ function removeFirstDot(txt) {
   return txt;
 }
 
-// we order files to avoid icons API to override some of the complex extensions.
-var orderedFiles = _.sortBy(files.supported, function (item) {
-  return item.contribOrder || 0;
-});
-var fileNames = _.reduce(orderedFiles, function (old, current) {
-  var contribType = current.contribType;
-  var icon = current.icon;
-  var oldObj = old;
-  current.extensions.forEach(function (o) {
-    if (contribType === ctype.filename) {
-      oldObj.names[o] = '_f_' + icon;
-    } else if (!contribType) {
-      oldObj.extensions[removeFirstDot(o)] = '_f_' + icon;
-    } else {
-      oldObj.languages[contribType] = '_f_' + icon;
-    }
-  });
-  return oldObj;
-}, { extensions: {}, names: {}, languages: {} });
 
-function getDefaultSchema() {
+/**
+ * Builds the structure for folders and files to use in the json file.
+ *
+ * @param {any} iconsFolderBasePath The base path to the icons folder
+ * @returns An object with folders and files properties
+ */
+function buildJsonStructure(iconsFolderBasePath) {
+  var suffix = '@2x';
+
+  return {
+    /**   folders section   **/
+    folders: folders.supported.reduce(function (old, current) {
+      var defs = old.defs;
+      var names = old.names;
+      var icon = current.icon;
+      var iconFolderType = 'folder_type_' + icon;
+      var folderPath = iconsFolderBasePath + iconFolderType;
+      var openFolderPath = folderPath + '_opened';
+      var iconFolderDefinition = '_fd_' + icon;
+      var iconOpenFolderDefinition = iconFolderDefinition + '_open';
+      var iconFileExtension = current.svg ? '.svg' : '.png';
+
+      defs[iconFolderDefinition] = {
+        iconPath: folderPath + suffix + iconFileExtension
+      };
+      defs[iconOpenFolderDefinition] = {
+        iconPath: openFolderPath + suffix + iconFileExtension
+      };
+
+      current.extensions.forEach(function (extension) {
+        var key = current.dot ? '.' + extension : extension;
+        names.folderNames[key] = iconFolderDefinition;
+        names.folderNamesExpanded[key] = iconOpenFolderDefinition;
+      });
+
+      return old;
+    }, { defs: {}, names: { folderNames: {}, folderNamesExpanded: {} } }),
+
+    /**   files section   **/
+    files: _.uniq(files.supported, true)
+      .reduce(function (old, current) {
+        var defs = old.defs;
+        var names = old.names;
+        var icon = current.icon;
+        var iconFileType = 'file_type_' + icon;
+        var filePath = iconsFolderBasePath + iconFileType;
+        var iconFileDefinition = '_f_' + icon;
+        var iconFileExtension = current.svg ? '.svg' : '.png';
+        var contribType = current.contribType;
+
+        defs[iconFileDefinition] = {
+          iconPath: filePath + suffix + iconFileExtension
+        };
+
+        current.extensions.forEach(function (extension) {
+          if (contribType === ctype.filename) {
+            names.fileNames[extension] = iconFileDefinition;
+          } else if (!contribType) {
+            names.fileExtensions[removeFirstDot(extension)] = iconFileDefinition;
+          } else {
+            names.languageIds[contribType] = iconFileDefinition;
+          }
+        });
+
+        return old;
+      }, { defs: {}, names: { fileExtensions: {}, fileNames: {}, languageIds: {} } })
+  };
+}
+
+/**
+ * Gets the default schema for the json file.
+ *
+ * @param {any} iconsFolderBasePath The base path to the icons folder
+ * @returns A json object with the apprepriate schema for vscode
+ */
+function getDefaultSchema(iconsFolderBasePath) {
   return {
     iconDefinitions: {
       _file: {
-        iconPath: './icons/File.svg'
+        iconPath: iconsFolderBasePath + 'File.svg'
       },
       _folder: {
-        iconPath: './icons/Folder_inverse.svg'
+        iconPath: iconsFolderBasePath + 'Folder_inverse.svg'
       },
       _folder_open: {
-        iconPath: './icons/Folder_opened.svg'
+        iconPath: iconsFolderBasePath + 'Folder_opened.svg'
       }
     },
     file: '_file',
@@ -90,24 +120,86 @@ function getDefaultSchema() {
 }
 
 
-function buildJsonFile(json) {
+/**
+ * Gets the relative path to the destination folder from the source directory.
+ *
+ * @param {any} toDirName The destination directory name
+ * @param {any} fromDirPath The path of the source diretory
+ * @returns The relative path to the destination directory
+ */
+function getPathToDirName(toDirName, fromDirPath) {
+  if (toDirName == null) {
+    throw new Error('toDirName not defined.');
+  }
+
+  if (fromDirPath == null) {
+    throw new Error('fromDirPath not defined.');
+  }
+
+  if (!fs.existsSync(toDirName)) {
+    throw new Error('Directory \'' + toDirName + '\' not found.');
+  }
+
+  return './' +
+    path.relative(fromDirPath, toDirName).replace('\\', '/') +
+    (toDirName.endsWith('/') ? '' : '/');
+}
+
+
+/**
+ * Write the json to a file.
+ *
+ * @param {any} json The Json object
+ * @param {any} iconsFilename The icons file name
+ * @param {any} outDir The output diretory
+ */
+function writeJsonToFile(json, iconsFilename, outDir) {
   try {
-    fs.writeFileSync('icons.json', JSON.stringify(json, null, 2));
-    console.log('icon contribution file successfully generated!'); // eslint-disable-line
+    if (!fs.existsSync(outDir)) {
+      fs.mkdir(outDir);
+    }
+
+    fs.writeFileSync(outDir + iconsFilename, JSON.stringify(json, null, 2));
+    console.log('Icon contribution file successfully generated!');
   } catch (error) {
-    console.log('something went wrong while generating the icon contribution file:', error); // eslint-disable-line
+    console.log('Something went wrong while generating the icon contribution file:', error);
   }
 }
 
-function generate() {
-  var iconfile = getDefaultSchema();
-  iconfile.iconDefinitions = Object.assign(iconfile.iconDefinitions, folderDefs, fileDefs);
-  iconfile.folderNames = folderNames.folders;
-  iconfile.folderNamesExpanded = folderNames.foldersOpen;
-  iconfile.fileExtensions = fileNames.extensions;
-  iconfile.fileNames = fileNames.names;
-  iconfile.languageIds = fileNames.languages;
-  buildJsonFile(iconfile);
+
+/**
+ * Generates an icon json file.
+ *
+ * @param {any} iconsFilename The icons file name
+ * @param {any} outDir The output diretory
+ */
+function generate(iconsFilename, outDir) {
+  var outputDir = outDir;
+
+  if (iconsFilename == null) {
+    throw new Error('iconsFilename not defined.');
+  }
+
+  if (outputDir == null) {
+    outputDir = './';
+  }
+
+  if (!outputDir.endsWith('/')) {
+    outputDir += '/';
+  }
+
+  var iconsFolderBasePath = getPathToDirName('icons', outputDir);
+  var res = buildJsonStructure(iconsFolderBasePath);
+  var json = getDefaultSchema(iconsFolderBasePath);
+
+  json.iconDefinitions = Object.assign(json.iconDefinitions, res.folders.defs, res.files.defs);
+  json.folderNames = res.folders.names.folderNames;
+  json.folderNamesExpanded = res.folders.names.folderNamesExpanded;
+  json.fileExtensions = res.files.names.fileExtensions;
+  json.fileNames = res.files.names.fileNames;
+  json.languageIds = res.files.names.languageIds;
+
+  writeJsonToFile(json, iconsFilename, outputDir);
 }
 
 module.exports = { generate: generate };

--- a/src/build/iconGenerator.js
+++ b/src/build/iconGenerator.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var files = require('./supportedExtensions').extensions;
 var folders = require('./supportedFolders').extensions;
 var ctype = require('./contribTypes');
+var packageJson = require('./../../package.json');
 
 
 /**
@@ -162,7 +163,30 @@ function writeJsonToFile(json, iconsFilename, outDir) {
     fs.writeFileSync(outDir + iconsFilename, JSON.stringify(json, null, 2));
     console.log('Icon contribution file successfully generated!');
   } catch (error) {
-    console.log('Something went wrong while generating the icon contribution file:', error);
+    console.error('Something went wrong while generating the icon contribution file:', error);
+  }
+}
+
+
+/**
+ * Updates the package.json file.
+ *
+ * @param {any} newIconThemesPath The new path of the icons directory.
+ */
+function updatePackageJson(newIconThemesPath) {
+  var oldIconThemesPath = packageJson.contributes.iconThemes[0].path;
+
+  if (!oldIconThemesPath || (oldIconThemesPath === newIconThemesPath)) {
+    return;
+  }
+
+  packageJson.contributes.iconThemes[0].path = newIconThemesPath;
+
+  try {
+    fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+    console.log('package.json updated');
+  } catch (err) {
+    console.error(err);
   }
 }
 
@@ -200,6 +224,7 @@ function generate(iconsFilename, outDir) {
   json.languageIds = res.files.names.languageIds;
 
   writeJsonToFile(json, iconsFilename, outputDir);
+  updatePackageJson(outputDir + iconsFilename);
 }
 
 module.exports = { generate: generate };

--- a/src/dev/extension.js
+++ b/src/dev/extension.js
@@ -52,7 +52,7 @@ function runAutoInstall() {
 }
 
 function activate() {
-  console.log('vscode-icons is active!');
+  console.log('vscode-icons is active!'); //eslint-disable-line
   runAutoInstall();
 }
 exports.activate = activate;

--- a/src/dev/messages.js
+++ b/src/dev/messages.js
@@ -1,10 +1,10 @@
-/* eslint-disable max-len */
 exports.messages = {
   newVersionMessage: 'Welcome to the new version of vscode-icons.',
   seeReleaseNotes: 'Information about the latest changes',
   dontshowthis: 'Don\'t show me this message next time',
   seeReadme: 'Learn about this extension',
-  welcomeMessage: 'vscode-icons now ships with official API support.  Go to File > Preferences > File Icon Theme and select VSCode Icons in order to activate.',
+  welcomeMessage: 'vscode-icons now ships with official API support. ' +
+  'Go to File > Preferences > File Icon Theme and select VSCode Icons in order to activate.',
   aboutOfficialApi: 'Learn more about File & Folder icons',
   learnMore: 'Want to learn more?',
   urlReleaseNote: 'https://github.com/robertohuertasm/vscode-icons/blob/master/CHANGELOG.md',


### PR DESCRIPTION
I took the liberty to refactor the functions of the build process.

List of changes:
- Made the functions more generic.
- Added the ability to generate the icons file to any directory, passing it as an argument to the `generate` function.
- Added functions comments.
- Added ability to find the relative path to the icons folder (handy if we decide to move the `icons.json` file to dist).
- Added `npm` script entry for `eslint` (this will help if we adopt a CI service).
- Added some `eslint` rules to get rid of inline rule exceptions.
- Added ability to auto-update the `package.json` file, if the icon theme path changes.
- Added sorting to the folders and files list on generating (now we don't care of the supported icon positioning in the list).

@robertohuertasm Keep what you like. Through it away if you don't like it.

