### PR TITLE
Improves the support for appveyor.

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -1114,6 +1114,7 @@
     ".htaccess": "_f_apache",
     ".htpasswd": "_f_apache",
     "appveyor.yml": "_f_appveyor",
+    ".appveyor.yml": "_f_appveyor",
     ".babelrc": "_f_babel",
     ".bowerrc": "_f_bower",
     "bower.json": "_f_bower",

--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -8,7 +8,7 @@ exports.extensions = {
     { icon: 'apache', extensions: ['.htaccess', '.htpasswd'], contribType: ctype.filename },
     { icon: 'apib', extensions: ['apib'] },
     { icon: 'applescript', extensions: ['app'] },
-    { icon: 'appveyor', extensions: ['appveyor.yml'], contribType: ctype.filename },
+    { icon: 'appveyor', extensions: ['appveyor.yml', '.appveyor.yml'], contribType: ctype.filename },
     { icon: 'ansible', extensions: ['ansible'] },
     { icon: 'asp', extensions: ['asp'] },
     { icon: 'aspx', extensions: ['aspx', 'ascx'] },


### PR DESCRIPTION
Some projects use a dotted filename `.appveyor.yml`. (see: https://github.com/angular/angular-cli)