### PR TITLE
Replase the use of underscore with lodash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.1.1",
     "ncp": "^2.0.0",
-    "underscore": "^1.8.3",
+    "lodash": "^4.17.2",
     "vscode": "^1.0.0"
   },
   "dependencies": {

--- a/src/build/iconGenerator.js
+++ b/src/build/iconGenerator.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var _ = require('underscore');
+var _ = require('lodash');
 var files = require('./supportedExtensions').extensions;
 var folders = require('./supportedFolders').extensions;
 var ctype = require('./contribTypes');
@@ -63,7 +63,7 @@ function buildJsonStructure(iconsFolderBasePath) {
       }, { defs: {}, names: { folderNames: {}, folderNamesExpanded: {} } }),
 
     /**   files section   **/
-    files: _.uniq(_.sortBy(files.supported, function (item) {
+    files: _.sortedUniq(_.sortBy(files.supported, function (item) {
       return item.icon;
     }), true)
       .reduce(function (old, current) {

--- a/src/dev/extension.js
+++ b/src/dev/extension.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console*/
 var vscode = require('vscode'); // eslint-disable-line
 var open = require('open');
 var msg = require('./messages').messages;


### PR DESCRIPTION
There are two key reasons for this PR.

1. `Lodash` v4 is officially a superset of `Underscore` (there was a plan to merge `Lodash` and `Underscore` as `Underdash` but it ended being `Lodash` v4)
2. `Lodash` is already included in `node_modules`, so it's an overkill to have also `Underscore`.
