### PR TITLE
Update eslint dependencies.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,12 @@
       "ForInStatement"
     ],
     "func-names": 0,
-    "vars-on-top": 0
+    "vars-on-top": 0,
+    "no-plusplus": [
+      2,
+      {
+        "allowForLoopAfterthoughts": true
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,11 +67,11 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "eslint": "^2.13.1",
-    "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-import": "^1.8.0",
-    "eslint-plugin-jsx-a11y": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint": "^3.12.0",
+    "eslint-config-airbnb": "^13.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.6.0",
     "ncp": "^2.0.0",
     "lodash": "^4.17.2",
     "vscode": "^1.0.0"

--- a/src/build/supportedExtensions.js
+++ b/src/build/supportedExtensions.js
@@ -197,18 +197,21 @@ exports.extensions = {
     { icon: 'vim', extensions: ['.vimrc', '.gvimrc'], contribType: ctype.filename, svg: true },
     { icon: 'volt', extensions: ['volt'] },
     {
-      icon: 'vscode', extensions: [
+      icon: 'vscode',
+      extensions: [
         'vscodeignore.json',
         'launch.json',
         'tasks.json',
         'jsconfig.json',
         'tsconfig.json',
         '.vscodeignore'
-      ], contribType: ctype.filename
+      ],
+      contribType: ctype.filename
     },
     { icon: 'vue', extensions: ['vue'] },
     {
-      icon: 'webpack', extensions: [
+      icon: 'webpack',
+      extensions: [
         'webpack.config.js',
         'webpack.config.common.js',
         'webpack.config.babel.js',
@@ -224,7 +227,8 @@ exports.extensions = {
         'webpack.config.prod.js',
         'webpack.config.ts',
         'webpack.config.coffee'
-      ], contribType: ctype.filename
+      ],
+      contribType: ctype.filename
     },
     { icon: 'wxml', extensions: ['wxml'] },
     { icon: 'wxss', extensions: ['wxss'] },

--- a/src/dev/extension.js
+++ b/src/dev/extension.js
@@ -1,4 +1,4 @@
-var vscode = require('vscode'); // eslint-disable-line
+var vscode = require('vscode');
 var open = require('open');
 var msg = require('./messages').messages;
 var settings = require('./settings');
@@ -36,15 +36,16 @@ function showNewVersionMessage() {
 function runAutoInstall() {
   var state = settings.getState();
   var isNewVersion = state.version !== vars.extVersion;
+
   if (!state.welcomeShown) {
     // show welcome message
     showWelcomeMessage();
-  } else {
-    if (isNewVersion) {
-      settings.setStatus(state.status);
-      if (vscode.workspace.getConfiguration().vsicons.dontShowNewVersionMessage) {
-        return;
-      }
+    return;
+  }
+
+  if (isNewVersion) {
+    settings.setStatus(state.status);
+    if (!vscode.workspace.getConfiguration().vsicons.dontShowNewVersionMessage) {
       showNewVersionMessage();
     }
   }

--- a/src/dev/settings.js
+++ b/src/dev/settings.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var vscode = require('vscode'); // eslint-disable-line
+var vscode = require('vscode');
 var semver = require('semver');
 var path = require('path');
 var getAppPath = require('./vscodePath');


### PR DESCRIPTION
This PR updates the dependency of `eslint`.

With the update the following issues get resolved:
 - ESLint issue with importing `vscode` which was marked as disbaled.

The ESLint update also enables some rules by default which have been dealt in code or eslint config.
