### PR TITLE
Introduce editorconfig rules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 indent_style = space
-indent_size = 4
-
-[package.json]
 indent_size = 2
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[package.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,13 @@
 {
-  "tslint.enable": true,
-  "editor.tabSize": 2,
-  "files.exclude": {
-        "out": false 
+    "editor.tabSize": 2,
+    "files.exclude": {
+        "out": false
     },
     "search.exclude": {
-        "out": true
+        "out": true,
+        "images": true,
+        "icons": true,
+        "examples": true
     },
     "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "tslint.enable": true,
     "editor.tabSize": 2,
     "files.exclude": {
         "out": false

--- a/package.json
+++ b/package.json
@@ -1,176 +1,176 @@
 {
-    "name": "vscode-icons",
-    "displayName": "vscode-icons",
-    "description": "Icons for Visual Studio Code",
-    "version": "6.0.0",
-    "publisher": "robertohuertasm",
-    "license": "MIT",
-    "author": {
-        "email": "roberto.huertas@outlook.com",
-        "name": "Roberto Huertas",
-        "url": "http://codecoding.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/robertohuertasm/vscode-icons"
-    },
-    "bugs": {
-        "url": "https://github.com/robertohuertasm/vscode-icons/issues",
-        "email": "roberto.huertas@outlook.com"
-    },
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other",
-        "Themes"
+  "name": "vscode-icons",
+  "displayName": "vscode-icons",
+  "description": "Icons for Visual Studio Code",
+  "version": "6.0.0",
+  "publisher": "robertohuertasm",
+  "license": "MIT",
+  "author": {
+    "email": "roberto.huertas@outlook.com",
+    "name": "Roberto Huertas",
+    "url": "http://codecoding.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robertohuertasm/vscode-icons"
+  },
+  "bugs": {
+    "url": "https://github.com/robertohuertasm/vscode-icons/issues",
+    "email": "roberto.huertas@outlook.com"
+  },
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": [
+    "Other",
+    "Themes"
+  ],
+  "keywords": [
+    "icon-theme",
+    "theme",
+    "icons",
+    "vscode-icons"
+  ],
+  "preview": false,
+  "homepage": "https://github.com/robertohuertasm/vscode-icons",
+  "icon": "images/logo.png",
+  "galleryBanner": {
+    "color": "#ffdd00"
+  },
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./out/src/",
+  "contributes": {
+    "iconThemes": [
+      {
+        "id": "vscode-icons",
+        "label": "VSCode Icons",
+        "path": "out/src/icons.json"
+      }
     ],
-    "keywords": [
-        "icon-theme",
-        "theme",
-        "icons",
-        "vscode-icons"
+    "commands": [
+      {
+        "command": "extension.regenerateIcons",
+        "title": "Apply Icons Customization",
+        "category": "Icons"
+      },
+      {
+        "command": "extension.ngPreset",
+        "title": "Toggle Angular Preset (Workspace Level)",
+        "category": "Icons"
+      },
+      {
+        "command": "extension.jsPreset",
+        "title": "Toggle Official JS Preset (User Level)",
+        "category": "Icons"
+      },
+      {
+        "command": "extension.tsPreset",
+        "title": "Toggle Official TS Preset (User Level)",
+        "category": "Icons"
+      },
+      {
+        "command": "extension.hideFoldersPreset",
+        "title": "Toggle Folder Icons Visibility (User Level)",
+        "category": "Icons"
+      },
+      {
+        "command": "extension.restoreIcons",
+        "title": "Restore Default Icon Manifest",
+        "category": "Icons"
+      }
     ],
-    "preview": false,
-    "homepage": "https://github.com/robertohuertasm/vscode-icons",
-    "icon": "images/logo.png",
-    "galleryBanner": {
-        "color": "#ffdd00"
-    },
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./out/src/",
-    "contributes": {
-        "iconThemes": [
-            {
-                "id": "vscode-icons",
-                "label": "VSCode Icons",
-                "path": "out/src/icons.json"
-            }
-        ],
-        "commands": [
-            {
-                "command": "extension.regenerateIcons",
-                "title": "Apply Icons Customization",
-                "category": "Icons"
-            },
-            {
-                "command": "extension.ngPreset",
-                "title": "Toggle Angular Preset (Workspace Level)",
-                "category": "Icons"
-            },
-            {
-                "command": "extension.jsPreset",
-                "title": "Toggle Official JS Preset (User Level)",
-                "category": "Icons"
-            },
-            {
-                "command": "extension.tsPreset",
-                "title": "Toggle Official TS Preset (User Level)",
-                "category": "Icons"
-            },
-            {
-                "command": "extension.hideFoldersPreset",
-                "title": "Toggle Folder Icons Visibility (User Level)",
-                "category": "Icons"
-            },
-            {
-                "command": "extension.restoreIcons",
-                "title": "Restore Default Icon Manifest",
-                "category": "Icons"
-            }
-        ],
-        "configuration": {
-            "title": "vscode-icons configuration",
-            "properties": {
-                "vsicons.dontShowNewVersionMessage": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If set to true the new version message won't be shown anymore."
-                },
-                "vsicons.presets.angular": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "If set to true the extension will match some of the common Angular patterns"
-                },
-                "vsicons.presets.jsOfficial": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If set to true the extension will use the official JS icon"
-                },
-                "vsicons.presets.tsOfficial": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If set to true the extension will use the official TS icon"
-                },
-                "vsicons.presets.hideFolders": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If set to true all folders will be hidden"
-                },
-                "vsicons.associations.files": {
-                    "type": "array",
-                    "default": [],
-                    "description": "These custom associations will override the file icon associations defined by default."
-                },
-                "vsicons.associations.folders": {
-                    "type": "array",
-                    "default": [],
-                    "description": "These custom associations will override the folder icon associations defined by default."
-                },
-                "vsicons.associations.fileDefault.file": {
-                    "type": "object",
-                    "default": null,
-                    "description": "This setting will let you change default dark file icon."
-                },
-                "vsicons.associations.fileDefault.file_light": {
-                    "type": "object",
-                    "default": null,
-                    "description": "This setting will let you change default light file icon."
-                },
-                "vsicons.associations.folderDefault.folder": {
-                    "type": "object",
-                    "default": null,
-                    "description": "This setting will let you change default dark folder icon."
-                },
-                "vsicons.associations.folderDefault.folder_light": {
-                    "type": "object",
-                    "default": null,
-                    "description": "This setting will let you change default light folder icon."
-                }
-            }
+    "configuration": {
+      "title": "vscode-icons configuration",
+      "properties": {
+        "vsicons.dontShowNewVersionMessage": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true the new version message won't be shown anymore."
+        },
+        "vsicons.presets.angular": {
+          "type": "boolean",
+          "default": true,
+          "description": "If set to true the extension will match some of the common Angular patterns"
+        },
+        "vsicons.presets.jsOfficial": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true the extension will use the official JS icon"
+        },
+        "vsicons.presets.tsOfficial": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true the extension will use the official TS icon"
+        },
+        "vsicons.presets.hideFolders": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true all folders will be hidden"
+        },
+        "vsicons.associations.files": {
+          "type": "array",
+          "default": [],
+          "description": "These custom associations will override the file icon associations defined by default."
+        },
+        "vsicons.associations.folders": {
+          "type": "array",
+          "default": [],
+          "description": "These custom associations will override the folder icon associations defined by default."
+        },
+        "vsicons.associations.fileDefault.file": {
+          "type": "object",
+          "default": null,
+          "description": "This setting will let you change default dark file icon."
+        },
+        "vsicons.associations.fileDefault.file_light": {
+          "type": "object",
+          "default": null,
+          "description": "This setting will let you change default light file icon."
+        },
+        "vsicons.associations.folderDefault.folder": {
+          "type": "object",
+          "default": null,
+          "description": "This setting will let you change default dark folder icon."
+        },
+        "vsicons.associations.folderDefault.folder_light": {
+          "type": "object",
+          "default": null,
+          "description": "This setting will let you change default light folder icon."
         }
-    },
-    "scripts": {
-        "prebuild": "npm run lint && npm run test",
-        "build": "node ./out/src/icon-manifest/build.js",
-        "example": "node ./out/src/example/example.js ",
-        "pretest": "npm run compile",
-        "test": "mocha ./out/test",
-        "lint": "tslint src/**/*.ts test/**/*.ts",
-        "test:vs": "node ./node_modules/vscode/bin/test",
-        "vscode:prepublish": "tsc -p ./",
-        "compile:w": "tsc -watch -p ./",
-        "compile": "tsc -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "@types/chai": "^3.4.34",
-        "@types/lodash": "^4.14.44",
-        "@types/mocha": "^2.2.33",
-        "@types/node": "^6.0.40",
-        "@types/sinon": "^1.16.34",
-        "chai": "^3.5.0",
-        "mocha": "^3.2.0",
-        "sinon": "^1.17.7",
-        "tslint": "^4.2.0",
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0"
-    },
-    "dependencies": {
-        "open": "0.0.5",
-        "semver": "^5.3.0",
-        "lodash": "^4.17.2"
+      }
     }
+  },
+  "scripts": {
+    "prebuild": "npm run lint && npm run test",
+    "build": "node ./out/src/icon-manifest/build.js",
+    "example": "node ./out/src/example/example.js ",
+    "pretest": "npm run compile",
+    "test": "mocha ./out/test",
+    "lint": "tslint src/**/*.ts test/**/*.ts",
+    "test:vs": "node ./node_modules/vscode/bin/test",
+    "vscode:prepublish": "tsc -p ./",
+    "compile:w": "tsc -watch -p ./",
+    "compile": "tsc -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/lodash": "^4.14.44",
+    "@types/mocha": "^2.2.33",
+    "@types/node": "^6.0.40",
+    "@types/sinon": "^1.16.34",
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "sinon": "^1.17.7",
+    "tslint": "^4.2.0",
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0"
+  },
+  "dependencies": {
+    "open": "0.0.5",
+    "semver": "^5.3.0",
+    "lodash": "^4.17.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "icons",
     "vscode-icons"
   ],
-  "preview": false,
+  "preview": true,
   "homepage": "https://github.com/robertohuertasm/vscode-icons",
   "icon": "images/logo.png",
   "galleryBanner": {


### PR DESCRIPTION
This PR introduces `editorconfig` ruling. This way we will get rid of the constant changing of spacing in `package.json`.

@robertohuertasm If you want `package.json` spacing as the rest of the `json` files just remove the `[package.json]` rule.
